### PR TITLE
[FIX] makefile.osx:134 *** missing separator.

### DIFF
--- a/src/makefile.osx
+++ b/src/makefile.osx
@@ -131,7 +131,7 @@ DEFS += $(addprefix -I,$(CURDIR)/leveldb/include) -DUSE_LEVELDB
 DEFS += $(addprefix -I,$(CURDIR)/leveldb/helpers)
 OBJS += obj/txdb-leveldb.o
 leveldb/libleveldb.a:
-  @echo "Building LevelDB ..."; cd leveldb; make; cd ..
+	@echo "Building LevelDB ..."; cd leveldb; make; cd ..
 obj/txdb-leveldb.o: leveldb/libleveldb.a
 else
 OBJS += obj/txdb-bdb.o


### PR DESCRIPTION
Replaced spaces with TAB
