### PR TITLE
[FIX] Wrong name for icns file for MacOS build

### DIFF
--- a/philosopherstone-qt.pro
+++ b/philosopherstone-qt.pro
@@ -382,7 +382,7 @@ macx:HEADERS += src/qt/macdockiconhandler.h
 macx:OBJECTIVE_SOURCES += src/qt/macdockiconhandler.mm
 macx:LIBS += -framework Foundation -framework ApplicationServices -framework AppKit
 macx:DEFINES += MAC_OSX MSG_NOSIGNAL=0
-macx:ICON = src/qt/res/icons/bitcoin.icns
+macx:ICON = src/qt/res/icons/Philosopherstone.icns
 macx:TARGET = "philosopherstone-qt"
 macx:QMAKE_CFLAGS_THREAD += -pthread
 macx:QMAKE_LFLAGS_THREAD += -pthread


### PR DESCRIPTION
Changed from Bitcoin.icns to Philosopherstone.icns
